### PR TITLE
Replaced occurrences of num_frames with numframes

### DIFF
--- a/soundcard/coreaudio.py
+++ b/soundcard/coreaudio.py
@@ -763,13 +763,13 @@ class _Recorder:
     def __exit__(self, exc_type, exc_value, traceback):
         self._au.close()
 
-    def record(self, num_frames):
+    def record(self, numframes):
         """Record some audio data.
 
         The data will be returned as a `frames × channels` float32
         numpy array.
 
-        This function will wait until `num_frames` frames have been
+        This function will wait until `numframes` frames have been
         recorded. However, the audio backend holds the final authority
         over how much audio data can be read at a time, so the
         returned amount of data will often be slightly larger than
@@ -778,7 +778,7 @@ class _Recorder:
 
         """
 
-        while sum(len(q) for q in self._queue) < (num_frames*self._au.channels)/self._au.resample:
+        while sum(len(q) for q in self._queue) < (numframes*self._au.channels)/self._au.resample:
             time.sleep(0.001)
 
         data = np.concatenate([np.frombuffer(_ffi.buffer(d), dtype='float32') for d in self._queue])

--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -336,13 +336,13 @@ class _Recorder(_Stream):
     def _connect_stream(self, bufattr):
         self._pulse._pa_stream_connect_record(self.stream, self._id.encode(), bufattr, _pa.PA_STREAM_ADJUST_LATENCY)
 
-    def record(self, num_frames):
+    def record(self, numframes):
         """Record some audio data.
 
         The data will be returned as a `frames × channels` float32
         numpy array.
 
-        This function will wait until `num_frames` frames have been
+        This function will wait until `numframes` frames have been
         recorded. However, the audio backend holds the final authority
         over how much audio data can be read at a time, so the
         returned amount of data will often be slightly larger than
@@ -355,7 +355,7 @@ class _Recorder(_Stream):
         captured_data = []
         data_ptr = _ffi.new('void**')
         nbytes_ptr = _ffi.new('size_t*')
-        while captured_frames < num_frames:
+        while captured_frames < numframes:
             readable_bytes = self._pulse._pa_stream_readable_size(self.stream)
             if readable_bytes > 0:
                 data_ptr[0] = _ffi.NULL


### PR DESCRIPTION
I happened to use this package and on PR #5 you mentioned that:

> I indeed mixed `num_frames` and `numframes` in a few places. It is supposed to be `numframes` everywhere.

So I just simply searched for the occurrences of `num_frames` with `numframes`, and judging by the code around it this should not break anything :)