### PR TITLE
Fixed blocksize support in _Recorder.record((with pulseaudio)

### DIFF
--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -336,7 +336,7 @@ class _Recorder(_Stream):
                  name='outputstream', fix_blocksize=False):
         super(_Recorder, self).__init__(id, samplerate, channels, blocksize, name)
         self._fix_blocksize = fix_blocksize
-        self._pending_chunk = numpy.zeros((0, self.channels))
+        self._pending_chunk = numpy.zeros((0, ))
 
     def _connect_stream(self, bufattr):
         self._pulse._pa_stream_connect_record(self.stream, self._id.encode(), bufattr, _pa.PA_STREAM_ADJUST_LATENCY)
@@ -356,8 +356,8 @@ class _Recorder(_Stream):
 
         """
 
-        captured_frames = self._pending_chunk.shape[0]
-        captured_data = [self._pending_chunk] if self.fix_blocksize else []
+        captured_frames = self._pending_chunk.shape[0] / self.channels
+        captured_data = [self._pending_chunk] if self._fix_blocksize else []
         data_ptr = _ffi.new('void**')
         nbytes_ptr = _ffi.new('size_t*')
         while captured_frames < numframes:
@@ -377,12 +377,17 @@ class _Recorder(_Stream):
             else:
                 time.sleep(0.001)
 
-        if self.fix_blocksize:
-            to_split = (len(chunk) - captured_frames + numframes) * self.channels
-            last_chunk = captured_data.pop()
-            keep, self._pending_chunk = np.split(last_chunk, to_split)
-            captures_data.append(keep)
-        return numpy.reshape(numpy.concatenate(captured_data), [-1, self.channels])
+        if self._fix_blocksize:
+            if len(captured_data) == 1:
+                keep , self._pending_chunk = numpy.split(self._pending_chunk,
+                                                    [int(numframes * self.channels)])
+                return numpy.reshape(keep, [-1, self.channels])
+            else:
+                to_split = int(len(chunk) - (captured_frames - numframes) * self.channels)
+                last_chunk = captured_data.pop()
+                keep, self._pending_chunk = numpy.split(last_chunk, [to_split])
+                captured_data.append(keep)
+                return numpy.reshape(numpy.concatenate(captured_data), [-1, self.channels])
 
     def flush(self):
         """Returns the last pending chunk
@@ -390,8 +395,8 @@ class _Recorder(_Stream):
         After using `record` with `fix_blocksize=True`, this will return the
         last incomplete chunk and clean it.
         """
-        last_chunk = np.reshape(self._pending_chunk, [-1, self.channels])
-        self._pending_chunk = np.zeros((0, self.channels))
+        last_chunk = numpy.reshape(self._pending_chunk, [-1, self.channels])
+        self._pending_chunk = numpy.zeros((0, ))
         return last_chunk
 
 

--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -178,15 +178,15 @@ class _Microphone(_SoundCard):
     def name(self):
         return self._get_info()['name']
 
-    def recorder(self, samplerate, channels=None, blocksize=None):
+    def recorder(self, samplerate, channels=None, blocksize=None, fix_blocksize=False):
         if channels is None:
             channels = self.channels
-        return _Recorder(self._id, samplerate, channels, blocksize)
+        return _Recorder(self._id, samplerate, channels, blocksize, fix_blocksize=fix_blocksize)
 
-    def record(self, numframes, samplerate, channels=None, blocksize=None):
+    def record(self, numframes, samplerate, channels=None, blocksize=None, fix_blocksize=False):
         if channels is None:
             channels = self.channels
-        with _Recorder(self._id, samplerate, channels, blocksize) as r:
+        with _Recorder(self._id, samplerate, channels, blocksize, fix_blocksize=fix_blocksize) as r:
             return r.record(numframes)
 
 
@@ -332,6 +332,11 @@ class _Recorder(_Stream):
     after it is closed.
 
     """
+    def __init__(self, id, samplerate, channels, blocksize=None,
+                 name='outputstream', fix_blocksize=False):
+        super(_Recorder, self).__init__(id, samplerate, channels, blocksize, name)
+        self._fix_blocksize = fix_blocksize
+        self._pending_chunk = numpy.zeros((0, self.channels))
 
     def _connect_stream(self, bufattr):
         self._pulse._pa_stream_connect_record(self.stream, self._id.encode(), bufattr, _pa.PA_STREAM_ADJUST_LATENCY)
@@ -351,8 +356,8 @@ class _Recorder(_Stream):
 
         """
 
-        captured_frames = 0
-        captured_data = []
+        captured_frames = self._pending_chunk.shape[0]
+        captured_data = [self._pending_chunk] if self.fix_blocksize else []
         data_ptr = _ffi.new('void**')
         nbytes_ptr = _ffi.new('size_t*')
         while captured_frames < numframes:
@@ -371,7 +376,23 @@ class _Recorder(_Stream):
                     captured_frames += len(chunk)/self.channels
             else:
                 time.sleep(0.001)
+
+        if self.fix_blocksize:
+            to_split = (len(chunk) - captured_frames + numframes) * self.channels
+            last_chunk = captured_data.pop()
+            keep, self._pending_chunk = np.split(last_chunk, to_split)
+            captures_data.append(keep)
         return numpy.reshape(numpy.concatenate(captured_data), [-1, self.channels])
+
+    def flush(self):
+        """Returns the last pending chunk
+
+        After using `record` with `fix_blocksize=True`, this will return the
+        last incomplete chunk and clean it.
+        """
+        last_chunk = np.reshape(self._pending_chunk, [-1, self.channels])
+        self._pending_chunk = np.zeros((0, self.channels))
+        return last_chunk
 
 
 def _lock(func):

--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -388,7 +388,9 @@ class _Recorder(_Stream):
                 keep, self._pending_chunk = numpy.split(last_chunk, [to_split])
                 captured_data.append(keep)
                 return numpy.reshape(numpy.concatenate(captured_data), [-1, self.channels])
-
+        else:
+            return numpy.reshape(numpy.concatenate(captured_data), [-1, self.channels])
+            
     def flush(self):
         """Returns the last pending chunk
 


### PR DESCRIPTION
Here are the proposed changes suggested in #10 

* Added the optional argument `fixed_blocksize` (default `False`) in the `_Recorder` class
* Added `_Rercorder.flush` method to empty and return the last unused chunk

Here is a working example
```
import soundcard as sc
import numpy as np

FS = 16000
CHUNK = 128
RECORD_SECONDS = 20
RECORD_STEP = int(float(FS * RECORD_SECONDS) / CHUNK)

default_speaker = sc.default_speaker()
default_mic = sc.default_microphone()

with default_mic.recorder(FS, blocksize=CHUNK, fix_blocksize=True) as mic,\
     default_speaker.player(FS, blocksize=CHUNK) as sp:
    for _ in range(RECORD_STEP):
        data = mic.record(CHUNK)
        if data.shape[0] != CHUNK:
            print('Not matching')
        sp.play(data)
last_chunk = mic.flush()
```

