### PR TITLE
Add support to `get_latency` with pulseaudio

### DIFF
--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -213,6 +213,7 @@ class _Stream:
         self._name = name
         self._blocksize = blocksize
         self.channels = channels
+        self.latency = _ffi.new("pa_usec_t*")
 
     def __enter__(self):
         self._pulse = _PulseAudio()
@@ -270,10 +271,9 @@ class _Stream:
 
     def get_latency(self):
         """ Get latency of the stream in sound card clock domain"""
-        usec_t = _ffi.new("pa_usec_t*")
         self._pulse._pa_stream_update_timing_info(self.stream, _ffi.NULL, _ffi.NULL)
-        self._pulse._pa_stream_get_latency(self.stream, usec_t, _ffi.NULL)
-        return usec_t[0]
+        self._pulse._pa_stream_get_latency(self.stream, self.latency, _ffi.NULL)
+        return self.latency[0]
 
 
 class _Player(_Stream):
@@ -621,7 +621,7 @@ class _PulseAudio:
     _pa_stream_peek = _lock(_pa.pa_stream_peek)
     _pa_stream_drop = _lock(_pa.pa_stream_drop)
     _pa_stream_connect_playback = _lock(_pa.pa_stream_connect_playback)
-    _pa_stream_update_timing_info = _lock(_pa.pa_stream_update_timing_info)
+    _pa_stream_update_timing_info = _lock_and_block(_pa.pa_stream_update_timing_info)
     _pa_stream_get_latency = _lock(_pa.pa_stream_get_latency)
     _pa_stream_get_buffer_attr = _lock(_pa.pa_stream_get_buffer_attr)
     _pa_stream_writable_size = _lock(_pa.pa_stream_writable_size)

--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -270,7 +270,7 @@ class _Stream:
 
     @property
     def latency(self):
-        """ Latency of the stream in sound card clock domain"""
+        """ Latency of the stream in seconds"""
         self._pulse._pa_stream_update_timing_info(self.stream, _ffi.NULL, _ffi.NULL)
         microseconds = _ffi.new("pa_usec_t*")
         self._pulse._pa_stream_get_latency(self.stream, microseconds, _ffi.NULL)

--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -268,6 +268,13 @@ class _Stream:
             # make sure that this definitely gets called no matter what:
             self._pulse.__exit__(exc_type, exc_value, traceback)
 
+    def get_latency(self):
+        """ Get latency of the stream in sound card clock domain"""
+        usec_t = _ffi.new("pa_usec_t*")
+        self._pulse._pa_stream_update_timing_info(self.stream, _ffi.NULL, _ffi.NULL)
+        self._pulse._pa_stream_get_latency(self.stream, usec_t, _ffi.NULL)
+        return usec_t[0]
+
 
 class _Player(_Stream):
     """A context manager for an active output stream.
@@ -614,6 +621,8 @@ class _PulseAudio:
     _pa_stream_peek = _lock(_pa.pa_stream_peek)
     _pa_stream_drop = _lock(_pa.pa_stream_drop)
     _pa_stream_connect_playback = _lock(_pa.pa_stream_connect_playback)
+    _pa_stream_update_timing_info = _lock(_pa.pa_stream_update_timing_info)
+    _pa_stream_get_latency = _lock(_pa.pa_stream_get_latency)
     _pa_stream_get_buffer_attr = _lock(_pa.pa_stream_get_buffer_attr)
     _pa_stream_writable_size = _lock(_pa.pa_stream_writable_size)
     _pa_stream_write = _lock(_pa.pa_stream_write)

--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -213,7 +213,6 @@ class _Stream:
         self._name = name
         self._blocksize = blocksize
         self.channels = channels
-        self._latency = _ffi.new("pa_usec_t*")
 
     def __enter__(self):
         self._pulse = _PulseAudio()
@@ -273,8 +272,9 @@ class _Stream:
     def latency(self):
         """ Latency of the stream in sound card clock domain"""
         self._pulse._pa_stream_update_timing_info(self.stream, _ffi.NULL, _ffi.NULL)
-        self._pulse._pa_stream_get_latency(self.stream, self._latency, _ffi.NULL)
-        return self._latency[0]
+        microseconds = _ffi.new("pa_usec_t*")
+        self._pulse._pa_stream_get_latency(self.stream, microseconds, _ffi.NULL)
+        return microseconds[0] / 1_000_000
 
 
 class _Player(_Stream):

--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -213,7 +213,7 @@ class _Stream:
         self._name = name
         self._blocksize = blocksize
         self.channels = channels
-        self.latency = _ffi.new("pa_usec_t*")
+        self._latency = _ffi.new("pa_usec_t*")
 
     def __enter__(self):
         self._pulse = _PulseAudio()
@@ -269,11 +269,12 @@ class _Stream:
             # make sure that this definitely gets called no matter what:
             self._pulse.__exit__(exc_type, exc_value, traceback)
 
-    def get_latency(self):
-        """ Get latency of the stream in sound card clock domain"""
+    @property
+    def latency(self):
+        """ Latency of the stream in sound card clock domain"""
         self._pulse._pa_stream_update_timing_info(self.stream, _ffi.NULL, _ffi.NULL)
-        self._pulse._pa_stream_get_latency(self.stream, self.latency, _ffi.NULL)
-        return self.latency[0]
+        self._pulse._pa_stream_get_latency(self.stream, self._latency, _ffi.NULL)
+        return self._latency[0]
 
 
 class _Player(_Stream):

--- a/soundcard/pulseaudio.py.h
+++ b/soundcard/pulseaudio.py.h
@@ -385,6 +385,7 @@ typedef enum pa_seek_mode {
 int pa_stream_write(pa_stream *p, const void *data, size_t nbytes, pa_free_cb_t free_cb, int64_t offset, pa_seek_mode_t seek);
 int pa_stream_peek(pa_stream *p, const void **data, size_t *nbytes);
 int pa_stream_drop(pa_stream *p);
+int pa_stream_get_latency(pa_stream *s, pa_usec_t *r_usec, int *negative);
 const pa_channel_map* pa_stream_get_channel_map(pa_stream *s);
 const pa_buffer_attr* pa_stream_get_buffer_attr(pa_stream *s);
 
@@ -399,3 +400,5 @@ pa_stream_state_t pa_stream_get_state(pa_stream *p);
 
 typedef void(*pa_stream_request_cb_t)(pa_stream *p, size_t nbytes, void *userdata);
 void pa_stream_set_read_callback(pa_stream *p, pa_stream_request_cb_t cb, void *userdata);
+
+pa_operation* pa_stream_update_timing_info(pa_stream *s, pa_stream_success_cb_t cb, void *userdata);


### PR DESCRIPTION
So I tried to integrate `pa_stream_get_latency` into `soundcard`.
I added `pa_stream_update_timing_info()` and `pa_stream_get_latency` into pulseaudio.py.h and in the `_PulseAudio` class in pulseaudio.py, both of them with `_lock`.
And finally I added a `get_latency` method to the `_Stream` class : it gets the timing updates and computes the latency. 
Would you consider adding this feature to `soundcard`?

My only problem is this : 
> The returned time is in the sound card clock domain, which usually runs at a slightly different rate than the system clock.
I've been looking for my soundcard's clock but without success and it would be really useful if we could convert this time to microseconds, any idea how to get the soundcard's clock speed? 

Example use : 
```
import soundcard as sc

# Constants
FS = 16000
CHUNK = 80
RECORD_SECONDS = 5
BS = 20
RECORD_STEP = int(float(FS * RECORD_SECONDS) / CHUNK)

default_speaker = sc.default_speaker()
default_mic = sc.default_microphone()
with default_mic.recorder(FS, blocksize=BS) as mic,\
     default_speaker.player(FS, blocksize=BS) as sp:
    for i in range(RECORD_STEP):
        data = mic.record(CHUNK)
        print('Microphone Latency: ', mic.get_latency())
        sp.play(data)
        print('Speaker Latency: ', sp.get_latency())
```
Am I right that the printed latencies correspond to the time (in the soundcard clock domain) between the moment the data was recorded and the moment the data was returned (for the microphone)? 