### PR TITLE
3.5 Compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     packages=['soundcard'],
     package_data={'soundcard': ['*.py.h']},
     install_requires=['numpy', 'cffi'],
-    python_requires='>=3.6',
+    python_requires='>=3.5',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
@@ -18,6 +18,7 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
         'Operating System :: OS Independent',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Topic :: Multimedia :: Sound/Audio :: Capture/Recording',

--- a/soundcard/mediafoundation.py
+++ b/soundcard/mediafoundation.py
@@ -224,7 +224,7 @@ class _DeviceEnumerator:
         elif kind == 'microphone':
             data_flow = 1 # capture
         else:
-            raise TypeError(f'Invalid kind: {kind}')
+            raise TypeError('Invalid kind: %s'.format(kind))
 
         DEVICE_STATE_ACTIVE = 0x1
         ppDevices = _ffi.new('IMMDeviceCollection **')
@@ -248,7 +248,7 @@ class _DeviceEnumerator:
         elif kind == 'microphone':
             data_flow = 1 # capture
         else:
-            raise TypeError(f'Invalid kind: {kind}')
+            raise TypeError('Invalid kind: %s'.format(kind))
 
         ppDevice = _ffi.new('IMMDevice **')
         eConsole = 0
@@ -408,7 +408,7 @@ class _Speaker(_Device):
         self._id = device._id
 
     def __repr__(self):
-        return f'<Speaker {self.name} ({self.channels} channels)>'
+        return '<Speaker %s (%d channels)>'.format(self.name,self.channels)
 
     def player(self, samplerate, channels=None, blocksize=None):
         if channels is None:
@@ -440,9 +440,9 @@ class _Microphone(_Device):
 
     def __repr__(self):
         if self.isloopback:
-            return f'<Loopback {self.name} ({self.channels} channels)>'
+            return '<Loopback %s (%d channels)>'.format(self.name,self.channels)
         else:
-            return f'<Microphone {self.name} ({self.channels} channels)>'
+            return '<Microphone %s (%d channels)>'.format(self.name,self.channels)
 
     def recorder(self, samplerate, channels=None, blocksize=None):
         if channels is None:
@@ -515,7 +515,7 @@ class _AudioClient:
         streamflags = 0x00100000 | 0x80000000 | 0x08000000 | 0x00080000
         if isloopback:
             streamflags |= 0x00020000 #loopback
-        bufferduration = int(blocksize/samplerate * 1000_000_0) # in hecto-nanoseconds
+        bufferduration = int(blocksize/samplerate * 10000000) # in hecto-nanoseconds (1000_000_0)
         hr = self._ptr[0][0].lpVtbl.Initialize(self._ptr[0], sharemode, streamflags, bufferduration, 0, ppMixFormat[0], _ffi.NULL)
         _com.check_error(hr)
         _combase.CoTaskMemFree(ppMixFormat[0])
@@ -533,7 +533,7 @@ class _AudioClient:
         pMinimumPeriod = _ffi.new("REFERENCE_TIME*")
         hr = self._ptr[0][0].lpVtbl.GetDevicePeriod(self._ptr[0], pDefaultPeriod, pMinimumPeriod)
         _com.check_error(hr)
-        return pDefaultPeriod[0]/1000_000_0, pMinimumPeriod[0]/1000_000_0
+        return pDefaultPeriod[0]/10000000, pMinimumPeriod[0]/10000000 # (1000_000_0)
 
     @property
     def currentpadding(self):

--- a/soundcard/mediafoundation.py
+++ b/soundcard/mediafoundation.py
@@ -224,7 +224,7 @@ class _DeviceEnumerator:
         elif kind == 'microphone':
             data_flow = 1 # capture
         else:
-            raise TypeError('Invalid kind: %s'.format(kind))
+            raise TypeError('Invalid kind: {}'.format(kind))
 
         DEVICE_STATE_ACTIVE = 0x1
         ppDevices = _ffi.new('IMMDeviceCollection **')
@@ -248,7 +248,7 @@ class _DeviceEnumerator:
         elif kind == 'microphone':
             data_flow = 1 # capture
         else:
-            raise TypeError('Invalid kind: %s'.format(kind))
+            raise TypeError('Invalid kind: {}'.format(kind))
 
         ppDevice = _ffi.new('IMMDevice **')
         eConsole = 0
@@ -408,7 +408,7 @@ class _Speaker(_Device):
         self._id = device._id
 
     def __repr__(self):
-        return '<Speaker %s (%d channels)>'.format(self.name,self.channels)
+        return '<Speaker {} ({} channels)>'.format(self.name,self.channels)
 
     def player(self, samplerate, channels=None, blocksize=None):
         if channels is None:
@@ -440,9 +440,9 @@ class _Microphone(_Device):
 
     def __repr__(self):
         if self.isloopback:
-            return '<Loopback %s (%d channels)>'.format(self.name,self.channels)
+            return '<Loopback {} ({} channels)>'.format(self.name,self.channels)
         else:
-            return '<Microphone %s (%d channels)>'.format(self.name,self.channels)
+            return '<Microphone {} ({} channels)>'.format(self.name,self.channels)
 
     def recorder(self, samplerate, channels=None, blocksize=None):
         if channels is None:

--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -418,7 +418,7 @@ class _Stream:
         self._pulse._pa_stream_update_timing_info(self.stream, _ffi.NULL, _ffi.NULL)
         microseconds = _ffi.new("pa_usec_t*")
         self._pulse._pa_stream_get_latency(self.stream, microseconds, _ffi.NULL)
-        return microseconds[0] / 1_000_000
+        return microseconds[0] / 1000000 # 1_000_000 (3.5 compat)
 
 
 class _Player(_Stream):

--- a/test_soundcard.py
+++ b/test_soundcard.py
@@ -43,7 +43,7 @@ def loopback_speaker():
         # pacmd load-module module-null-sink channels=6 rate=48000
         return soundcard.get_speaker('Null')
     else:
-        raise RuntimeError('Unknown platform %s'.format(sys.platform))
+        raise RuntimeError('Unknown platform {}'.format(sys.platform))
 
 @pytest.fixture
 def loopback_player(loopback_speaker):
@@ -61,7 +61,7 @@ def loopback_microphone():
     elif sys.platform == 'linux':
         return soundcard.get_microphone('Null', include_loopback=True)
     else:
-        raise RuntimeError('Unknown platform %s'.format(sys.platform))
+        raise RuntimeError('Unknown platform {}'.format(sys.platform))
 
 @pytest.fixture
 def loopback_recorder(loopback_microphone):

--- a/test_soundcard.py
+++ b/test_soundcard.py
@@ -43,7 +43,7 @@ def loopback_speaker():
         # pacmd load-module module-null-sink channels=6 rate=48000
         return soundcard.get_speaker('Null')
     else:
-        raise RuntimeError(f'Unknown platform {sys.platform}')
+        raise RuntimeError('Unknown platform %s'.format(sys.platform))
 
 @pytest.fixture
 def loopback_player(loopback_speaker):
@@ -61,7 +61,7 @@ def loopback_microphone():
     elif sys.platform == 'linux':
         return soundcard.get_microphone('Null', include_loopback=True)
     else:
-        raise RuntimeError(f'Unknown platform {sys.platform}')
+        raise RuntimeError('Unknown platform %s'.format(sys.platform))
 
 @pytest.fixture
 def loopback_recorder(loopback_microphone):


### PR DESCRIPTION
**EDIT**: No longer WIP, the issue described here disappeared after switching to different system.

This is a work in progress attempting to get SoundCard working with Python 3.5, fixing #45.

The reason this specific version is important is because the Raspberry Pi is stuck at 3.5, since it is based on debian stable. I am working on code that uses SoundCard, but must also work on the Pi. 

Thus far, I have replaced all f-strings with explicit format statements and removed underscores from numbers. This makes python 3.5 stop complaining about syntax errors, and makes microphone work.

Unfortunately, there is something wrong with media playback on 3.5. I tried the following:
```python3
import soundcard
mic = soundcard.default_microphone()
s = soundcard.default_speaker()
r = mic.record(5*44100,44100)
s.play(r,44100)
```
With a manually compiled 3.7 on the Pi it works without issue, but the default 3.5 gives the following error:

```
Assertion 's' failed at pulse/stream.c:1399, function pa_stream_connect_playback(). Aborting.
```

This means that the pull request is not ready for merging - I am currently unsure why the error above shows up for 3.5 but not 3.7, but am hopeful that it is something easy to fix.