### PR TITLE
fix exception when monitor is default pulseaudio device

### DIFF
--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -100,7 +100,7 @@ def default_microphone():
     """
     with _PulseAudio() as p:
         name = p.server_info['default source id']
-        return get_microphone(name)
+        return get_microphone(name, exclude_monitors=False)
 
 
 def get_microphone(id, include_loopback=False, exclude_monitors=True):


### PR DESCRIPTION
this fixes #52, in the sense that it prevents an exception occuring. It may not be the desired behaviour though...