### PR TITLE
Add local pyinstaller hook

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,4 +25,10 @@ setup(
         'Topic :: Multimedia :: Sound/Audio :: Players',
     ],
     long_description=open('README.rst').read(),
+    entry_points={
+        "pyinstaller40": [
+            "hook-dirs = soundcard.__pyinstaller:get_hook_dirs",
+            "tests = soundcard.__pyinstaller:get_test_dirs",
+        ],
+    },
 )

--- a/soundcard/__pyinstaller/__init__.py
+++ b/soundcard/__pyinstaller/__init__.py
@@ -1,0 +1,12 @@
+from os.path import dirname
+
+
+HERE = dirname(__file__)
+
+
+def get_hook_dirs():
+    return [HERE]
+
+
+def get_test_dirs():
+    return [HERE]

--- a/soundcard/__pyinstaller/conftest.py
+++ b/soundcard/__pyinstaller/conftest.py
@@ -1,0 +1,1 @@
+from PyInstaller.utils.conftest import *  # noqa

--- a/soundcard/__pyinstaller/hook-soundcard.py
+++ b/soundcard/__pyinstaller/hook-soundcard.py
@@ -1,0 +1,7 @@
+"""
+Hook for https://pypi.org/project/SoundCard/
+"""
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('soundcard')

--- a/soundcard/__pyinstaller/test_soundcard.py
+++ b/soundcard/__pyinstaller/test_soundcard.py
@@ -1,0 +1,6 @@
+def test_pyi_soundcard(pyi_builder):
+    pyi_builder.test_source(
+        """
+        import soundcard
+    """
+    )


### PR DESCRIPTION
This should remedy #77 by having a local pyinstaller hook according to the new pyinstaller community hooks.

as proposed in https://github.com/pyinstaller/pyinstaller/pull/4834

@Legorooj could you perhaps validate this method as I just grabbed the wgpu example and rolled with it