### PR TITLE
Add pyinstaller to package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author='Bastian Bechtold',
     url='https://github.com/bastibe/SoundCard',
     license='BSD 3-clause',
-    packages=['soundcard'],
+    packages=['soundcard', 'soundcard.__pyinstaller'],
     package_data={'soundcard': ['*.py.h']},
     install_requires=['numpy', 'cffi'],
     python_requires='>=3.5',


### PR DESCRIPTION
oops my bad @bastibe I made a small mistake in my previous commit my apologies.

Forgot to add it to the setup.py else pip totally ignores the new __pyinstaller package.

Just tested it and it seems to work quite nicely :D 