### PR TITLE
fix documentation on get_speaker and get_microphone, id cannot be an int (except for coreaudio)

### DIFF
--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -288,8 +288,8 @@ def get_speaker(id):
 
     Parameters
     ----------
-    id : str
-        can be a backend id string, a substring of the
+    id : int or str
+        can be a backend id string (Windows, Linux) or a device id int (MacOS), a substring of the
         speaker name, or a fuzzy-matched pattern for the speaker name.
 
     Returns
@@ -350,8 +350,8 @@ def get_microphone(id, include_loopback=False, exclude_monitors=True):
 
     Parameters
     ----------
-    id : str
-        can be a backend id string, a substring of the
+    id : int or str
+        can be a backend id string (Windows, Linux) or a device id int (MacOS), a substring of the
         speaker name, or a fuzzy-matched pattern for the speaker name.
     include_loopback : bool
         allow recording of speaker outputs

--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -288,7 +288,7 @@ def get_speaker(id):
 
     Parameters
     ----------
-    id : int or str
+    id : str
         can be a backend id string, a substring of the
         speaker name, or a fuzzy-matched pattern for the speaker name.
 
@@ -350,7 +350,7 @@ def get_microphone(id, include_loopback=False, exclude_monitors=True):
 
     Parameters
     ----------
-    id : int or str
+    id : str
         can be a backend id string, a substring of the
         speaker name, or a fuzzy-matched pattern for the speaker name.
     include_loopback : bool

--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -289,7 +289,7 @@ def get_speaker(id):
     Parameters
     ----------
     id : int or str
-        can be an int index, a backend id, a substring of the
+        can be a backend id string, a substring of the
         speaker name, or a fuzzy-matched pattern for the speaker name.
 
     Returns
@@ -351,7 +351,7 @@ def get_microphone(id, include_loopback=False, exclude_monitors=True):
     Parameters
     ----------
     id : int or str
-        can be an int index, a backend id, a substring of the
+        can be a backend id string, a substring of the
         speaker name, or a fuzzy-matched pattern for the speaker name.
     include_loopback : bool
         allow recording of speaker outputs


### PR DESCRIPTION
fixes #101 

the device id in get_speaker and get_microphone cannot be an int index