### PR TITLE
return pulseaudio errno exception on stream creation failure

### DIFF
--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -237,6 +237,7 @@ class _PulseAudio:
     _pa_context_drain = _lock(_pa.pa_context_drain)
     _pa_context_disconnect = _lock(_pa.pa_context_disconnect)
     _pa_context_unref = _lock(_pa.pa_context_unref)
+    _pa_context_errno = _lock(_pa.pa_context_errno)
     _pa_operation_get_state = _lock(_pa.pa_operation_get_state)
     _pa_operation_unref = _lock(_pa.pa_operation_unref)
     _pa_stream_get_state = _lock(_pa.pa_stream_get_state)

--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -653,6 +653,9 @@ class _Stream:
             raise RuntimeError('invalid channel map')
 
         self.stream = _pulse._pa_stream_new(_pulse.context, self._name.encode(), samplespec, channelmap)
+        if not self.stream:
+            errno = _pulse._pa_context_errno(_pulse.context)
+            raise RuntimeError("stream creation failed with error ", errno)
         bufattr = _ffi.new("pa_buffer_attr*")
         bufattr.maxlength = 2**32-1 # max buffer length
         numchannels = self.channels if isinstance(self.channels, int) else len(self.channels)

--- a/soundcard/pulseaudio.py.h
+++ b/soundcard/pulseaudio.py.h
@@ -159,6 +159,7 @@ typedef enum pa_context_flags {PA_CONTEXT_NOFLAGS = 0} pa_context_flags_t;
 typedef struct pa_spawn_api pa_spawn_api;
 int pa_context_connect(pa_context *c, const char *server, pa_context_flags_t flags, const pa_spawn_api *api);
 void pa_context_disconnect(pa_context *c);
+int pa_context_errno(const pa_context *c);
 typedef enum pa_context_state {
     PA_CONTEXT_UNCONNECTED,
     PA_CONTEXT_CONNECTING,


### PR DESCRIPTION
Make the pa_context_errno call available in SoundCard, so we
can better debug what is going wrong with pulseaudio.

Signed-off-by: Rik van Riel <riel@surriel.com>