### PR TITLE
avoid garbage collection related stream creation failure

### DIFF
--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -644,8 +644,8 @@ class _Stream:
         if not _pulse._pa_sample_spec_valid(samplespec):
             raise RuntimeError('invalid sample spec')
 
-        channelmap = _ffi.new("pa_channel_map*")
-        channelmap = _pa.pa_channel_map_init_auto(channelmap, samplespec.channels, _pa.PA_CHANNEL_MAP_DEFAULT)
+        pam = _ffi.new("pa_channel_map*")
+        channelmap = _pa.pa_channel_map_init_auto(pam, samplespec.channels, _pa.PA_CHANNEL_MAP_DEFAULT)
         if isinstance(self.channels, collections.Iterable):
             for idx, ch in enumerate(self.channels):
                 channelmap.map[idx] = ch+1

--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -644,6 +644,8 @@ class _Stream:
         if not _pulse._pa_sample_spec_valid(samplespec):
             raise RuntimeError('invalid sample spec')
 
+        # pam and channelmap refer to the same object, but need different
+        # names to avoid garbage collection trouble on the Python/C boundary
         pam = _ffi.new("pa_channel_map*")
         channelmap = _pa.pa_channel_map_init_auto(pam, samplespec.channels, _pa.PA_CHANNEL_MAP_DEFAULT)
         if isinstance(self.channels, collections.Iterable):


### PR DESCRIPTION
C has pointers, Python does not. Python has garbage collection,
C does not. The function pa_channel_map_init_auto returns, on
success, a pointer to the same pa_channel_map object that was
passed to the function as a parameter.

Apparently this confuses Pyton/CFFI, which can sometimes garbage
collect that old (now properly initialized) object, resulting in
pa_stream_new getting a pa_channel_map object that is not properly
initialized, and throwing an error.

Using separate variable names for the pa_channel_map object passed
to pa_channel_map_init_auto and the one returned seems to avoid
that issue, even though they are the same structure.

Signed-off-by: Rik van Riel <riel@surriel.com>