### PR TITLE
Added index search for get_microphone()

### DIFF
--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -369,8 +369,7 @@ def get_microphone(id, include_loopback=False, exclude_monitors=True):
         include_loopback = not exclude_monitors
 
     microphones = _pulse.source_list
-    return _Microphone(id=_match_soundcard(str(id), microphones, include_loopback)['id'])
-
+    return _Microphone(id=_match_soundcard(id, microphones, include_loopback)['id'])
 
 def _match_soundcard(id, soundcards, include_loopback=False):
     """Find id in a list of soundcards.
@@ -390,7 +389,7 @@ def _match_soundcard(id, soundcards, include_loopback=False):
     # index search
     try:
         return soundcards[int(id)]
-    except (ValueError):
+    except (ValueError,IndexError):
         pass
 
     # id search

--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -369,7 +369,7 @@ def get_microphone(id, include_loopback=False, exclude_monitors=True):
         include_loopback = not exclude_monitors
 
     microphones = _pulse.source_list
-    return _Microphone(id=_match_soundcard(id, microphones, include_loopback)['id'])
+    return _Microphone(id=_match_soundcard(str(id), microphones, include_loopback)['id'])
 
 
 def _match_soundcard(id, soundcards, include_loopback=False):
@@ -386,19 +386,29 @@ def _match_soundcard(id, soundcards, include_loopback=False):
     else:
         soundcards_by_id = {soundcard['id']: soundcard for soundcard in soundcards}
         soundcards_by_name = {soundcard['name']: soundcard for soundcard in soundcards}
+
+    # index search
+    try:
+        return soundcards[int(id)]
+    except (ValueError):
+        pass
+
+    # id search
     if id in soundcards_by_id:
         return soundcards_by_id[id]
+
     # try substring match:
     for name, soundcard in soundcards_by_name.items():
         if id in name:
             return soundcard
+
     # try fuzzy match:
     pattern = '.*'.join(id)
     for name, soundcard in soundcards_by_name.items():
         if re.match(pattern, name):
             return soundcard
-    raise IndexError('no soundcard with id {}'.format(id))
 
+    raise IndexError('no soundcard with id {}'.format(id))
 
 def get_name():
     """Get application name.


### PR DESCRIPTION
as stated by the docs:

`
Parameters: | id (int or str) – can be an int index, a backend id, a substring of the speaker name, or a fuzzy-matched pattern for the speaker name.`

This is not true and caused me to bash my face on my computer for all of last night before I thought it could be an upstream issue. Please merge this. Thanks.