### PR TITLE
Try explicit file name, if the general does not work (e.g. on nixos)

### DIFF
--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -13,8 +13,12 @@ _package_dir, _ = os.path.split(__file__)
 with open(os.path.join(_package_dir, 'pulseaudio.py.h'), 'rt') as f:
     _ffi.cdef(f.read())
 
-_pa = _ffi.dlopen('pulse')
-
+try:
+    _pa = _ffi.dlopen('pulse')
+except:
+    # Need sometimes explicite sharedobject name on Linux
+    _pa = _ffi.dlopen('libpulse.so')
+    
 # First, we need to define a global _PulseAudio proxy for interacting
 # with the C API:
 

--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -16,7 +16,7 @@ with open(os.path.join(_package_dir, 'pulseaudio.py.h'), 'rt') as f:
 try:
     _pa = _ffi.dlopen('pulse')
 except OSError:
-    # Need sometimes explicite sharedobject name on Linux
+    # Try explicit file name, if the general does not work (e.g. on nixos)
     _pa = _ffi.dlopen('libpulse.so')
     
 # First, we need to define a global _PulseAudio proxy for interacting

--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -15,7 +15,7 @@ with open(os.path.join(_package_dir, 'pulseaudio.py.h'), 'rt') as f:
 
 try:
     _pa = _ffi.dlopen('pulse')
-except:
+except OSError:
     # Need sometimes explicite sharedobject name on Linux
     _pa = _ffi.dlopen('libpulse.so')
     


### PR DESCRIPTION
On Nixos 21.05 need a explicite name to load pulse library