### PR TITLE
get_microphone(), get_speaker(): Improved comparison between the call parameter "id" and existing device names

### DIFF
--- a/soundcard/coreaudio.py
+++ b/soundcard/coreaudio.py
@@ -8,6 +8,8 @@ import math
 import threading
 import warnings
 
+from soundcard.utils import match_device
+
 _ffi = cffi.FFI()
 _package_dir, _ = os.path.split(__file__)
 with open(os.path.join(_package_dir, 'coreaudio.py.h'), 'rt') as f:
@@ -60,7 +62,7 @@ def get_speaker(id):
     fuzzy-matched pattern for the speaker name.
 
     """
-    return _match_device(id, all_speakers())
+    return match_device(id, all_speakers())
 
 
 def default_microphone():
@@ -79,30 +81,7 @@ def get_microphone(id, include_loopback=False):
     fuzzy-matched pattern for the microphone name.
 
     """
-    return _match_device(id, all_microphones(include_loopback))
-
-
-def _match_device(id, devices):
-    """Find id in a list of devices.
-
-    id can be a CoreAudio id, a substring of the device name, or a
-    fuzzy-matched pattern for the microphone name.
-
-    """
-    devices_by_id = {device.id: device for device in devices}
-    devices_by_name = {device.name: device for device in devices}
-    if id in devices_by_id:
-        return devices_by_id[id]
-    # try substring match:
-    for name, device in devices_by_name.items():
-        if id in name:
-            return device
-    # try fuzzy match:
-    pattern = '.*'.join(id)
-    for name, device in devices_by_name.items():
-        if re.match(pattern, name):
-            return device
-    raise IndexError('no device with id {}'.format(id))
+    return match_device(id, all_microphones(include_loopback))
 
 
 def get_name():

--- a/soundcard/coreaudio.py
+++ b/soundcard/coreaudio.py
@@ -3,7 +3,6 @@ import cffi
 import numpy
 import collections
 import time
-import re
 import math
 import threading
 import warnings

--- a/soundcard/mediafoundation.py
+++ b/soundcard/mediafoundation.py
@@ -2,7 +2,6 @@
 
 import os
 import cffi
-import re
 import time
 import struct
 import collections

--- a/soundcard/mediafoundation.py
+++ b/soundcard/mediafoundation.py
@@ -10,6 +10,8 @@ import platform
 
 import numpy
 
+from soundcard.utils import match_device
+
 _ffi = cffi.FFI()
 _package_dir, _ = os.path.split(__file__)
 with open(os.path.join(_package_dir, 'mediafoundation.py.h'), 'rt') as f:
@@ -123,7 +125,7 @@ def get_speaker(id):
     fuzzy-matched pattern for the speaker name.
 
     """
-    return _match_device(id, all_speakers())
+    return match_device(id, all_speakers())
 
 def all_microphones(include_loopback=False):
     """A list of all connected microphones.
@@ -151,29 +153,7 @@ def get_microphone(id, include_loopback=False):
     fuzzy-matched pattern for the microphone name.
 
     """
-    return _match_device(id, all_microphones(include_loopback))
-
-def _match_device(id, devices):
-    """Find id in a list of devices.
-
-    id can be a WASAPI id, a substring of the device name, or a
-    fuzzy-matched pattern for the microphone name.
-
-    """
-    devices_by_id = {device.id: device for device in devices}
-    devices_by_name = {device.name: device for device in devices}
-    if id in devices_by_id:
-        return devices_by_id[id]
-    # try substring match:
-    for name, device in devices_by_name.items():
-        if id in name:
-            return device
-    # try fuzzy match:
-    pattern = '.*'.join(id)
-    for name, device in devices_by_name.items():
-        if re.match(pattern, name):
-            return device
-    raise IndexError('no device with id {}'.format(id))
+    return match_device(id, all_microphones(include_loopback))
 
 def _str2wstr(string):
     """Converts a Python str to a Windows WSTR_T."""

--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -2,7 +2,6 @@ import os
 import atexit
 import collections
 import time
-import re
 import threading
 import warnings
 import numpy

--- a/soundcard/utils.py
+++ b/soundcard/utils.py
@@ -1,0 +1,21 @@
+def match_device(id, devices):
+    """Find id in a list of devices.
+
+    id can be a platfom-specific id, a substring of the device name, or a
+    fuzzy-matched pattern for the microphone name.
+
+    """
+    devices_by_id = {device.id: device for device in devices}
+    devices_by_name = {device.name: device for device in devices}
+    if id in devices_by_id:
+        return devices_by_id[id]
+    # try substring match:
+    for name, device in devices_by_name.items():
+        if id in name:
+            return device
+    # try fuzzy match:
+    pattern = '.*'.join(id)
+    for name, device in devices_by_name.items():
+        if re.match(pattern, name):
+            return device
+    raise IndexError('no device with id {}'.format(id))

--- a/soundcard/utils.py
+++ b/soundcard/utils.py
@@ -1,21 +1,39 @@
+import re
+
 def match_device(id, devices):
     """Find id in a list of devices.
 
-    id can be a platfom-specific id, a substring of the device name, or a
+    id can be a platfom specific id, a substring of the device name, or a
     fuzzy-matched pattern for the microphone name.
-
     """
     devices_by_id = {device.id: device for device in devices}
-    devices_by_name = {device.name: device for device in devices}
+    real_devices_by_name = {
+        device.name: device for device in devices
+        if not getattr(device, 'isloopback', True)}
+    loopback_devices_by_name = {
+        device.name: device for device in devices
+        if getattr(device, 'isloopback', True)}
     if id in devices_by_id:
         return devices_by_id[id]
+    for device_map in real_devices_by_name, loopback_devices_by_name:
+        if id in device_map:
+            return device_map[id]
     # try substring match:
-    for name, device in devices_by_name.items():
-        if id in name:
-            return device
+    for device_map in real_devices_by_name, loopback_devices_by_name:
+        for name, device in device_map.items():
+            if id in name:
+                return device
     # try fuzzy match:
-    pattern = '.*'.join(id)
-    for name, device in devices_by_name.items():
-        if re.match(pattern, name):
-            return device
+    id_parts = list(id)
+    # Escape symbols in the provided id that have a special meaning
+    # in regular expression to prevent syntax errors e.g. for
+    # unbalanced parentheses.
+    for special_re_char in r'.^$*+?{}\[]|()':
+        while special_re_char in id_parts:
+            id_parts[id_parts.index(special_re_char)] = '\\' + special_re_char
+    pattern = '.*'.join(id_parts)
+    for device_map in real_devices_by_name, loopback_devices_by_name:
+        for name, device in device_map.items():
+            if re.search(pattern, name):
+                return device
     raise IndexError('no device with id {}'.format(id))

--- a/test_soundcard.py
+++ b/test_soundcard.py
@@ -3,6 +3,14 @@ import soundcard
 import numpy
 import pytest
 
+
+if sys.platform == 'linux':
+    import soundcard.pulseaudio as platform_lib
+elif sys.platform == 'darwin':
+    import soundcard.coreaudio as platform_lib
+elif sys.platform == 'win32':
+    import soundcard.mediafoundation as platform_lib
+
 skip_if_not_linux = pytest.mark.skipif(sys.platform != 'linux', reason='Only implemented for PulseAudio so far')
 
 ones = numpy.ones(1024)
@@ -157,3 +165,147 @@ def test_loopback_multichannel_channelmap(loopback_speaker, loopback_microphone)
     assert right.mean() < 0
     assert (left > 0.5).sum() == len(signal)
     assert (right < -0.5).sum() == len(signal)
+
+
+class FakeMicrophone:
+    def __init__(self, id, name, isloopback):
+        self.id = id
+        self.name = name
+        self.isloopback = isloopback
+
+
+fake_microphones = [
+    FakeMicrophone(
+        'alsa_output.usb-PCM2702-00.analog-stereo.monitor',
+        'Monitor of PCM2702 16-bit stereo audio DAC Analog Stereo',
+        True),
+    FakeMicrophone(
+        'alsa_output.pci-0000_00_1b.0.analog-stereo.monitor',
+        'Monitor of Build-in Sound Device Analog Stereo',
+        True),
+    FakeMicrophone(
+        'alsa_input.pci-0000_00_1b.0.analog-stereo',
+        'Build-in Sound Device Analog Stereo',
+        False),
+    FakeMicrophone(
+        'alsa_output.pci-0000_00_03.0.hdmi-stereo-extra1.monitor',
+        'Monitor of Build-in Sound Device Digital Stereo (HDMI 2)',
+        True),
+    FakeMicrophone(
+        'alsa_input.bluetooth-stuff.monitor',
+        'Name with regex pitfalls [).',
+        True),
+    FakeMicrophone(
+        'alsa_input.bluetooth-stuff',
+        'Name with regex pitfalls [). Longer than than the lookback name.',
+        False),
+    ]
+
+@pytest.fixture
+def mock_all_microphones(monkeypatch):
+
+    def mocked_all_microphones(include_loopback=False, exclude_monitors=True):
+        return fake_microphones
+
+    monkeypatch.setattr(
+        platform_lib, "all_microphones", mocked_all_microphones)
+
+
+def test_get_microphone(mock_all_microphones):
+    # Internal IDs can be specified.
+    mic = soundcard.get_microphone('alsa_input.pci-0000_00_1b.0.analog-stereo')
+    assert mic == fake_microphones[2]
+    # No fuzzy matching for IDs.
+    with pytest.raises(IndexError) as exc_info:
+        soundcard.get_microphone('alsa_input.pci-0000_00_1b.0')
+    assert (
+        exc_info.exconly() ==
+        'IndexError: no device with id alsa_input.pci-0000_00_1b.0')
+
+    # The name of a microphone can be specified.
+    mic = soundcard.get_microphone('Build-in Sound Device Analog Stereo')
+    assert mic == fake_microphones[2]
+
+    # Complete name matches have precedence over substring matches.
+    mic = soundcard.get_microphone('Name with regex pitfalls [).')
+    assert mic == fake_microphones[4]
+
+    mic = soundcard.get_microphone('Name with regex pitfalls')
+    assert mic == fake_microphones[5]
+
+
+    # A substring of a device name can be specified. If the parameter passed
+    # to get_microphone() is a substring of more than one microphone name,
+    # real microphones are preferably returned.
+    mic = soundcard.get_microphone('Sound Device Analog')
+    assert mic == fake_microphones[2]
+
+    # If none of the lookup methods above matches a device, a "fuzzy match"
+    # is tried.
+    mic = soundcard.get_microphone('Snd Dev Analog')
+    assert mic == fake_microphones[2]
+
+    # "Fuzzy matching" uses a regular expression; symbols with a specail
+    # meaning in regexes are escaped.
+    mic = soundcard.get_microphone('regex pitfall [')
+    assert mic == fake_microphones[5]
+
+
+class FakeSpeaker:
+    def __init__(self, id, name):
+        self.id = id
+        self.name = name
+
+
+fake_speakers = [
+    FakeSpeaker(
+        'alsa_output.usb-PCM2702-00.analog-stereo',
+        'PCM2702 16-bit stereo audio DAC Analog Stereo'),
+    FakeSpeaker(
+        'alsa_output.pci-0000_00_1b.0.analog-stereo',
+        'Build-in Sound Device Analog Stereo'),
+    FakeSpeaker(
+        'alsa_output.pci-0000_00_03.0.hdmi-stereo-extra1',
+        'Build-in Sound Device Digital Stereo (HDMI 2)'),
+    FakeSpeaker(
+        'alsa_output.wire_fire_thingy',
+        r'A nonsensical name \[a-z]{3}'),
+    ]
+
+@pytest.fixture
+def mock_all_speakers(monkeypatch):
+
+    def mocked_all_speakers(include_loopback=False, exclude_monitors=True):
+        return fake_speakers
+
+    monkeypatch.setattr(
+        platform_lib, "all_speakers", mocked_all_speakers)
+
+def test_get_speaker(mock_all_speakers):
+    # Internal IDs can be specified.
+    spk = soundcard.get_speaker('alsa_output.pci-0000_00_1b.0.analog-stereo')
+    assert spk == fake_speakers[1]
+    # No fuzzy matching for IDs.
+    with pytest.raises(IndexError) as exc_info:
+        soundcard.get_speaker('alsa_output.pci-0000_00_1b.0')
+    assert (
+        exc_info.exconly() ==
+        'IndexError: no device with id alsa_output.pci-0000_00_1b.0')
+
+    # The name of a speaker can be specified.
+    spk = soundcard.get_speaker('Build-in Sound Device Analog Stereo')
+    assert spk == fake_speakers[1]
+
+    # Substrings of a device name can be specified.
+    spk = soundcard.get_speaker('Sound Device Analog')
+    assert spk == fake_speakers[1]
+
+    # If none of the lookup methods above matches a device, a "fuzzy match"
+    # is tried.
+    spk = soundcard.get_speaker('Snd Dev Analog')
+    assert spk == fake_speakers[1]
+
+    # "Fuzzy matching" uses a regular expression; symbols with a specail
+    # meaning in regexes are escaped.
+    spk = soundcard.get_speaker('nonsense {3')
+    assert spk == fake_speakers[3]


### PR DESCRIPTION
This PR fixes the problems mentioned in #146 , "Problems with the "fuzzy matcher" in `get_microphone()`.

The changes are a bit longer than I expected at first, but anyway:

I moved the functions `_match_device()` from the modules `coreaudio` and `mediafoundation` into a new module `utils` so that the same implementation can be used for all platforms. `pulseaudio` has of course a similar change to use `utils.match_device()`.

Changes to match_device():

1. I added another name lookup in `match_device()`: Before the function checks if the call parameter `id` is a substring of one of the device names, it checks if the call parameter **identical** with any of the device names. While I also added your suggestion to separate real and loopback devices in name lookups (see below), there still is at least in theory still a corner case without this "name identity lookup": A loopback device could have a name that is the substring of a real microphone. Admitted, not very likely, but you never know ;) If only a substring lookup for the loopback device is done where real devices have precedence, the loopback device would not be returned. (See also the diff of test_soundcard, line 229. That test will fail without the additional "full name check".)
2. Symbols with a special meaning in regexes are escaped if they appear in the call parameter `id* . (I'd appreciate a double-check if I got all relevant symbols when I read https://docs.python.org/3/library/re.html#regular-expression-syntax ...)

Final note: I am not too happy with the tests I wrote: I think it would be nice to have some device names and IDs from Windows and MacOS too in the tests. Problem, as already mentioned in #146 : I have neither a Mac nor a machine with a Windows installation. But I'm happy to add device names from MacOS/Windows if I get some examples.