### PR TITLE
Pa channelmap

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,14 +145,66 @@ Channel Maps
 
 Some professional sound cards have large numbers of channels. If you want to
 record or play only a subset of those channels, you can specify a channel map.
-For playback, a channel map of ``[0, 3, 4]`` will play three-channel audio data
-on the physical channels one, four, and five. For recording, a channel map of
-``[0, 3, 4]`` will return three-channel audio data recorded from the physical
-channels one, four, and five.
+A channel map consists of a list of channel specifiers, which refer to the
+channels of the audio backend in use. The index of each of those specifiers
+in the the channel map list indicates the channel index in the numpy data array
+used in SoundCard:
 
-In addition, pulseaudio/Linux defines channel ``-1`` as the mono mix of all
-channels for both playback and recording. CoreAudio/macOS defines channel ``-1``
-as silence for both playback and recording.
+.. code:: python
+    # record one second of audio from backend channels 0 to 3:
+    data = default_mic.record(samplerate=48000, channels=[0, 1, 2, 3], numframes=48000)
+
+    # play back the recorded audio in reverse channel order:
+    default_speaker.play(data=data, channels=[3, 2, 1, 0], samplerate=48000)
+
+The meaning of the channel specifiers depend on the backend in use. For WASAPI
+(Windows) and CoreAudio (macOS) the indices refer to the physical output
+channels of the sound device in use. For the PulseAudio backend (Linux) the
+specifiers refer to logical channel positions instead of physical hardware
+channels.
+
+The channel position identifiers in the PulseAudio backend are based on:
+https://freedesktop.org/software/pulseaudio/doxygen/channelmap_8h.html
+Since the mapping of position indices to audio channels is not obvious, a
+dictionary containing all possible positions and channel indices can be
+retrieved by calling ``channel_name_map()``. The positions for the indices up to 10 are ::
+    'mono': -1,
+    'left': 0,
+    'right': 1,
+    'center': 2,
+    'rear-center': 3,
+    'rear-left': 4,
+    'rear-right': 5,
+    'lfe': 6,
+    'front-left-of-center': 7,
+    'front-right-of-center': 8,
+    'side-left': 9,
+    'side-right': 10
+
+The identifier ``mono`` or the index ``-1`` can be used for mono mix of all
+channels for both playback and recording. (CoreAudio/macOS defines channel ``-1``
+as silence for both playback and recording.) In addition to the indices, the PulseAudio
+backend allows the use of the name strings to define a channel map ::
+
+.. code:: python
+    # This example plays one second of noise on each channel defined in the channel map consecutively.
+    # The channel definition scheme using strings only works with the PulseAudio backend!
+
+    # This defines a channel map for a 7.1 audio sink device
+    channel_map = ['left', 'right', 'center', 'lfe', 'rear-left', 'rear-right', 'side-left', 'side-right']
+
+    num_channels = len(channel_map)
+    samplerate = 48000
+
+    # Create the multi channel noise array.
+    noise_samples = 48000
+    noise = numpy.random.uniform(-0.1, 0.1, noise_samples)
+    data = numpy.zeros((num_channels * noise_samples, num_channels), dtype=numpy.float32)
+    for channel in range(num_channels):
+        data[channel * noise_samples:(channel + 1) * noise_samples, channel] = noise
+
+    # Playback using the 7.1 channel map.
+    default_speaker.play(data=data, channels=channel_map, samplerate=samplerate)
 
 FAQ
 ---

--- a/README.rst
+++ b/README.rst
@@ -151,11 +151,13 @@ in the the channel map list indicates the channel index in the numpy data array
 used in SoundCard:
 
 .. code:: python
+
     # record one second of audio from backend channels 0 to 3:
     data = default_mic.record(samplerate=48000, channels=[0, 1, 2, 3], numframes=48000)
 
     # play back the recorded audio in reverse channel order:
     default_speaker.play(data=data, channels=[3, 2, 1, 0], samplerate=48000)
+
 
 The meaning of the channel specifiers depend on the backend in use. For WASAPI
 (Windows) and CoreAudio (macOS) the indices refer to the physical output
@@ -167,7 +169,7 @@ The channel position identifiers in the PulseAudio backend are based on:
 https://freedesktop.org/software/pulseaudio/doxygen/channelmap_8h.html
 Since the mapping of position indices to audio channels is not obvious, a
 dictionary containing all possible positions and channel indices can be
-retrieved by calling ``channel_name_map()``. The positions for the indices up to 10 are ::
+retrieved by calling ``channel_name_map()``. The positions for the indices up to 10 are: ::
     'mono': -1,
     'left': 0,
     'right': 1,
@@ -184,9 +186,10 @@ retrieved by calling ``channel_name_map()``. The positions for the indices up to
 The identifier ``mono`` or the index ``-1`` can be used for mono mix of all
 channels for both playback and recording. (CoreAudio/macOS defines channel ``-1``
 as silence for both playback and recording.) In addition to the indices, the PulseAudio
-backend allows the use of the name strings to define a channel map ::
+backend allows the use of the name strings to define a channel map:
 
 .. code:: python
+
     # This example plays one second of noise on each channel defined in the channel map consecutively.
     # The channel definition scheme using strings only works with the PulseAudio backend!
 

--- a/README.rst
+++ b/README.rst
@@ -209,6 +209,33 @@ backend allows the use of the name strings to define a channel map:
     # Playback using the 7.1 channel map.
     default_speaker.play(data=data, channels=channel_map, samplerate=samplerate)
 
+The available channels of each PulseAudio source or sink can be listed by ::
+
+    > pactl list sinks
+    > pactl list sources
+
+
+The ``Channel Map`` property lists the channel identifier of the source/sink. ::
+
+    > pactl list sinks | grep  "Channel Map" -B 6
+    
+    Sink #486
+        State: SUSPENDED
+        Name: alsa_output.usb-C-Media_Electronics_Inc._USB_Advanced_Audio_Device-00.analog-stereo
+        Description: USB Advanced Audio Device Analog Stereo
+        Driver: PipeWire
+        Sample Specification: s24le 2ch 48000Hz
+        Channel Map: front-left,front-right
+    --
+    Sink #488
+            State: RUNNING
+            Name: alsa_output.pci-0000_2f_00.4.analog-surround-71
+            Description: Starship/Matisse HD Audio Controller Analog Surround 7.1
+            Driver: PipeWire
+            Sample Specification: s32le 8ch 48000Hz
+            Channel Map: front-left,front-right,rear-left,rear-right,front-center,lfe,side-left,side-right
+
+
 FAQ
 ---
 Q: How to make it work on a headless Raspberry Pi?

--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -47,40 +47,21 @@ def _lock_and_block(func):
     return func_with_lock
 
 
-_channel_positions = {
-                         'left': _pa.PA_CHANNEL_POSITION_LEFT,
-                         'right': _pa.PA_CHANNEL_POSITION_RIGHT,
-                         'center': _pa.PA_CHANNEL_POSITION_CENTER,
-                         'subwoofer': _pa.PA_CHANNEL_POSITION_SUBWOOFER} | \
-                     {
-                         _ffi.string(_pa.pa_channel_position_to_string(idx)).decode('utf-8'): idx for idx in
-                         range(_pa.PA_CHANNEL_POSITION_MAX)
-                     }
-
-
-def get_channel_positions():
+def channel_name_map():
     """
-    Return a dict containing the Pulseaudio channel position enum type index
-    for every channel position name string.
+    Return a dict containing the channel position index for every channel position name string.
     """
-    return _channel_positions
 
-
-def channel_position_to_string(channel):
-    """
-    Return the Pulseaudio channel position name string for enum type index channel.
-    """
-    return _ffi.string(_pa.pa_channel_position_to_string(channel)).decode('utf-8')
-
-
-def channel_string_to_position(channel_string):
-    """
-    Return the Pulseaudio channel position enum type index for position name channel_string.
-    """
-    channel = _pa.pa_channel_position_from_string(_ffi.new("char[]", channel_string.encode()))
-    if channel == -1:
-        raise KeyError(channel_string + " is not a valid channel position name.")
-    return channel
+    channel_indices = {
+                          'left': _pa.PA_CHANNEL_POSITION_LEFT,
+                          'right': _pa.PA_CHANNEL_POSITION_RIGHT,
+                          'center': _pa.PA_CHANNEL_POSITION_CENTER,
+                          'subwoofer': _pa.PA_CHANNEL_POSITION_SUBWOOFER} | \
+                      {
+                          _ffi.string(_pa.pa_channel_position_to_string(idx)).decode('utf-8'): idx for idx in
+                          range(_pa.PA_CHANNEL_POSITION_MAX)
+                      }
+    return channel_indices
 
 
 class _PulseAudio:
@@ -694,7 +675,8 @@ class _Stream:
                 if isinstance(ch, int):
                     channelmap.map[idx] = ch
                 else:
-                    channelmap.map[idx] = channel_string_to_position(ch)
+                    channel_name_to_index = channel_name_map()
+                    channelmap.map[idx] = channel_name_to_index[ch]
 
         if not _pa.pa_channel_map_valid(channelmap):
             raise RuntimeError('invalid channel map')

--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -46,6 +46,43 @@ def _lock_and_block(func):
         self._pa_operation_unref(operation)
     return func_with_lock
 
+
+_channel_positions = {
+                         'left': _pa.PA_CHANNEL_POSITION_LEFT,
+                         'right': _pa.PA_CHANNEL_POSITION_RIGHT,
+                         'center': _pa.PA_CHANNEL_POSITION_CENTER,
+                         'subwoofer': _pa.PA_CHANNEL_POSITION_SUBWOOFER} | \
+                     {
+                         _ffi.string(_pa.pa_channel_position_to_string(idx)).decode('utf-8'): idx for idx in
+                         range(_pa.PA_CHANNEL_POSITION_MAX)
+                     }
+
+
+def get_channel_positions():
+    """
+    Return a dict containing the Pulseaudio channel position enum type index
+    for every channel position name string.
+    """
+    return _channel_positions
+
+
+def channel_position_to_string(channel):
+    """
+    Return the Pulseaudio channel position name string for enum type index channel.
+    """
+    return _ffi.string(_pa.pa_channel_position_to_string(channel)).decode('utf-8')
+
+
+def channel_string_to_position(channel_string):
+    """
+    Return the Pulseaudio channel position enum type index for position name channel_string.
+    """
+    channel = _pa.pa_channel_position_from_string(_ffi.new("char[]", channel_string.encode()))
+    if channel == -1:
+        raise KeyError(channel_string + " is not a valid channel position name.")
+    return channel
+
+
 class _PulseAudio:
     """Proxy for communcation with Pulseaudio.
 
@@ -654,7 +691,11 @@ class _Stream:
         channelmap = _pa.pa_channel_map_init_extend(pam, samplespec.channels, _pa.PA_CHANNEL_MAP_DEFAULT)
         if isinstance(self.channels, collections.abc.Iterable):
             for idx, ch in enumerate(self.channels):
-                channelmap.map[idx] = ch+1
+                if isinstance(ch, int):
+                    channelmap.map[idx] = ch
+                else:
+                    channelmap.map[idx] = channel_string_to_position(ch)
+
         if not _pa.pa_channel_map_valid(channelmap):
             raise RuntimeError('invalid channel map')
 

--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -53,16 +53,18 @@ def channel_name_map():
     """
 
     channel_indices = {
-                          'left': _pa.PA_CHANNEL_POSITION_LEFT,
-                          'right': _pa.PA_CHANNEL_POSITION_RIGHT,
-                          'center': _pa.PA_CHANNEL_POSITION_CENTER,
-                          'subwoofer': _pa.PA_CHANNEL_POSITION_SUBWOOFER} | \
-                      {
-                          _ffi.string(_pa.pa_channel_position_to_string(idx)).decode('utf-8'): idx for idx in
-                          range(_pa.PA_CHANNEL_POSITION_MAX)
-                      }
+        _ffi.string(_pa.pa_channel_position_to_string(idx)).decode('utf-8'): idx for idx in
+        range(_pa.PA_CHANNEL_POSITION_MAX)
+    }
 
-    # The above values returned from Pulseaudio contain 1 for 'left', 2 for 'right' and so on.
+    # Append alternative names for front-left, front-right, front-center and lfe according to
+    # the PulseAudio definitions.
+    channel_indices.update({'left': _pa.PA_CHANNEL_POSITION_LEFT,
+                            'right': _pa.PA_CHANNEL_POSITION_RIGHT,
+                            'center': _pa.PA_CHANNEL_POSITION_CENTER,
+                            'subwoofer': _pa.PA_CHANNEL_POSITION_SUBWOOFER})
+
+    # The values returned from Pulseaudio contain 1 for 'left', 2 for 'right' and so on.
     # SoundCard's channel indices for 'left' start at 0. Therefore, we have to decrement all values.
     channel_indices = {key: value - 1 for (key, value) in channel_indices.items()}
 

--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -61,6 +61,11 @@ def channel_name_map():
                           _ffi.string(_pa.pa_channel_position_to_string(idx)).decode('utf-8'): idx for idx in
                           range(_pa.PA_CHANNEL_POSITION_MAX)
                       }
+
+    # The above values returned from Pulseaudio contain 1 for 'left', 2 for 'right' and so on.
+    # SoundCard's channel indices for 'left' start at 0. Therefore, we have to decrement all values.
+    channel_indices = {key: value - 1 for (key, value) in channel_indices.items()}
+
     return channel_indices
 
 
@@ -673,10 +678,10 @@ class _Stream:
         if isinstance(self.channels, collections.abc.Iterable):
             for idx, ch in enumerate(self.channels):
                 if isinstance(ch, int):
-                    channelmap.map[idx] = ch
+                    channelmap.map[idx] = ch + 1
                 else:
                     channel_name_to_index = channel_name_map()
-                    channelmap.map[idx] = channel_name_to_index[ch]
+                    channelmap.map[idx] = channel_name_to_index[ch] + 1
 
         if not _pa.pa_channel_map_valid(channelmap):
             raise RuntimeError('invalid channel map')

--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -776,7 +776,8 @@ class _Player(_Stream):
         if data.shape[1] != self.channels:
             raise TypeError('second dimension of data must be equal to the number of channels, not {}'.format(data.shape[1]))
         while data.nbytes > 0:
-            nwrite = _pulse._pa_stream_writable_size(self.stream) // 4
+            nwrite = _pulse._pa_stream_writable_size(self.stream) // (4 * self.channels) # 4 bytes per sample
+
             if nwrite == 0:
                 time.sleep(0.001)
                 continue

--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -651,7 +651,7 @@ class _Stream:
         # pam and channelmap refer to the same object, but need different
         # names to avoid garbage collection trouble on the Python/C boundary
         pam = _ffi.new("pa_channel_map*")
-        channelmap = _pa.pa_channel_map_init_auto(pam, samplespec.channels, _pa.PA_CHANNEL_MAP_DEFAULT)
+        channelmap = _pa.pa_channel_map_init_extend(pam, samplespec.channels, _pa.PA_CHANNEL_MAP_DEFAULT)
         if isinstance(self.channels, collections.abc.Iterable):
             for idx, ch in enumerate(self.channels):
                 channelmap.map[idx] = ch+1

--- a/soundcard/pulseaudio.py.h
+++ b/soundcard/pulseaudio.py.h
@@ -111,6 +111,8 @@ typedef enum pa_channel_map_def {
 
 pa_channel_map* pa_channel_map_init_extend(pa_channel_map *m, unsigned channels, pa_channel_map_def_t def);
 int pa_channel_map_valid(const pa_channel_map *map);
+const char* pa_channel_position_to_string(pa_channel_position_t pos);
+pa_channel_position_t pa_channel_position_from_string(const char *s);
 
 typedef struct pa_buffer_attr {
     uint32_t maxlength;

--- a/soundcard/pulseaudio.py.h
+++ b/soundcard/pulseaudio.py.h
@@ -112,7 +112,6 @@ typedef enum pa_channel_map_def {
 pa_channel_map* pa_channel_map_init_extend(pa_channel_map *m, unsigned channels, pa_channel_map_def_t def);
 int pa_channel_map_valid(const pa_channel_map *map);
 const char* pa_channel_position_to_string(pa_channel_position_t pos);
-pa_channel_position_t pa_channel_position_from_string(const char *s);
 
 typedef struct pa_buffer_attr {
     uint32_t maxlength;

--- a/soundcard/pulseaudio.py.h
+++ b/soundcard/pulseaudio.py.h
@@ -109,7 +109,7 @@ typedef enum pa_channel_map_def {
     PA_CHANNEL_MAP_DEFAULT = PA_CHANNEL_MAP_AIFF
 } pa_channel_map_def_t;
 
-pa_channel_map* pa_channel_map_init_auto(pa_channel_map *m, unsigned channels, pa_channel_map_def_t def);
+pa_channel_map* pa_channel_map_init_extend(pa_channel_map *m, unsigned channels, pa_channel_map_def_t def);
 int pa_channel_map_valid(const pa_channel_map *map);
 
 typedef struct pa_buffer_attr {


### PR DESCRIPTION
 This branch introduces changes to the behavior of the channel map handling in the Pulseaudio
backend. 

- It fixes the crash which occurs if more  6 channels are selected.
- It adds the possibility to set a list of Pulseaudio channel position name
strings to the channels parameter of the speaker and recorder functions.
- There are new helper functions to support the use of channel position
strings: channel_position_to_string(channel) and channel_string_to_position(channel_string)
to convert indices to strings and vice versa and get_channel_positions(),
which returns a dicts containing all possible channel position strings with
the according indices.
- The increment of the channel map indices prior to passing them to the
Pulseaudio channel map is removed. This way the indices match the Pulseaudio
pa_channel_position type. This will break existing code wich makes use of
custom channel maps.

For a lengthy explanation see https://github.com/bastibe/SoundCard/issues/115 