### PR TITLE
Hard latency restriction for the PulseAudio backend.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,13 @@ In order to request lower latencies, pass a ``blocksize`` to ``player`` or
 try to honor your request as best it can. On Windows/WASAPI, setting
 ``exclusive_mode=True`` might help, too (this is currently experimental).
 
+In Linux, it is possible to restrict the latency by setting the optional
+parameter ``maxlatency``, which takes an integer number of samples. The setting
+of this parameter limits the buffer size of the PulseAudio backend. If your
+algorithm cannot keep up with the playback/recording, buffer underflows or overflows
+will occur. Underflow and overflow events can be displayed by setting the optional
+argument ``report_under_overflow`` to ``True``.
+
 Another source of latency is in the ``record`` function, which buffers output up
 to the requested ``numframes``. In general, for optimal latency, you should use
 a ``numframes`` significantly lower than the ``blocksize`` above, maybe by a

--- a/soundcard/pulseaudio.py.h
+++ b/soundcard/pulseaudio.py.h
@@ -415,5 +415,9 @@ pa_stream_state_t pa_stream_get_state(pa_stream *p);
 
 typedef void(*pa_stream_request_cb_t)(pa_stream *p, size_t nbytes, void *userdata);
 void pa_stream_set_read_callback(pa_stream *p, pa_stream_request_cb_t cb, void *userdata);
+typedef void (*pa_stream_notify_cb_t)(pa_stream *p, void *userdata);
+void pa_stream_set_overflow_callback(pa_stream *p, pa_stream_notify_cb_t cb, void *userdata);
+void pa_stream_set_underflow_callback(pa_stream *p, pa_stream_notify_cb_t cb, void *userdata);
+int64_t pa_stream_get_underflow_index(const pa_stream *p);
 
 pa_operation* pa_stream_update_timing_info(pa_stream *s, pa_stream_success_cb_t cb, void *userdata);


### PR DESCRIPTION
The changes add two optional arguments to the player and recorder functions:
- ` `maxlatency`` is translated to the PulseAudio ``bufattr.maxlength`` parameter, which sets a limit for the internal audio buffer and such restricts latency.
- ``report_under_overflow`` is an optional boolean debug argument, which enables the reporting of buffer underflows and overflows to the terminal.

The changes are meant for use-cases, which prioritize a defined latency over interruption-free playback/recording.