### PR TITLE
Fix empty soundcard list on macOS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -312,3 +312,5 @@ Changelog
 - 2021-12-23 fixes deprecation for Python 3.10
   (Thank you, Nekyo!)
 - 2022-04-29 fixes deprecation in recent Numpy
+- 2024-03-16 fixes empty soundcard list on macOS
+  (Thank you, Patrice Brend'amour!)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='SoundCard',
-    version='0.4.2',
+    version='0.4.3',
     description='Play and record audio without resorting to CPython extensions',
     author='Bastian Bechtold',
     url='https://github.com/bastibe/SoundCard',

--- a/soundcard/coreaudio.py
+++ b/soundcard/coreaudio.py
@@ -260,8 +260,7 @@ class _CoreAudio:
         err = _ca.AudioObjectGetPropertyData(target, prop, 0, _ffi.NULL,
                                              size, prop_data)
         assert err == 0, "Can't get Core Audio property data"
-
-        return [prop_data[idx] for idx in range(num_values)]
+        return prop_data
 
     @staticmethod
     def set_property(target, selector, prop_data, scope=_cac.kAudioObjectPropertyScopeGlobal):
@@ -505,9 +504,10 @@ class _AudioUnit:
                                           data, datasize)
         if status != 0:
             raise RuntimeError(_cac.error_number_to_string(status))
-        if num_values == 1:
+        # return trivial data trivially
+        if num_values == 1 and (type == "UInt32" or type == "Float64"):
             return data[0]
-        else:
+        else:  # everything else, return the cdata, to keep it alive
             return data
 
     @property

--- a/soundcard/coreaudio.py
+++ b/soundcard/coreaudio.py
@@ -423,7 +423,7 @@ class _AudioUnit:
 
         audiocomponent = _au.AudioComponentFindNext(_ffi.NULL, desc)
         if not audiocomponent:
-            raise Runtime("could not find audio component")
+            raise RuntimeError("could not find audio component")
         self.ptr = _ffi.new("AudioComponentInstance*")
         status = _au.AudioComponentInstanceNew(audiocomponent, self.ptr)
         if status:

--- a/soundcard/coreaudio.py
+++ b/soundcard/coreaudio.py
@@ -480,6 +480,7 @@ class _AudioUnit:
             self.channels = channels
         else:
             raise TypeError('channels must be iterable or integer')
+        self._set_channels(self.channels)
 
     def _set_property(self, property, scope, element, data):
         if '[]' in _ffi.typeof(data).cname:
@@ -562,16 +563,7 @@ class _AudioUnit:
             _cac.kAudioUnitProperty_SampleRate,
             self._au_scope, self._au_element, data)
 
-    @property
-    def channels(self):
-        streamformat = self._get_property(
-            _cac.kAudioUnitProperty_StreamFormat,
-            self._au_scope, self._au_element, "AudioStreamBasicDescription")
-        assert streamformat
-        return streamformat.mChannelsPerFrame
-
-    @channels.setter
-    def channels(self, channels):
+    def _set_channels(self, channels):
         streamformat = _ffi.new(
             "AudioStreamBasicDescription*",
             dict(mSampleRate=self.samplerate,


### PR DESCRIPTION
A use-after-free bug and a channel corruption were broken on macOS.

Thank you tremendously, @drallgood, for helping me figure this one out!