### PR TITLE
add support for loopback recording on macOS 14.2+

### DIFF
--- a/soundcard/coreaudio.py.h
+++ b/soundcard/coreaudio.py.h
@@ -32,11 +32,63 @@ typedef UInt16                  UTF16Char;
 typedef UInt8                   UTF8Char;
 typedef signed long long CFIndex;
 typedef const void * CFStringRef;
+typedef unsigned long long      CFHashCode;
+typedef const void *            CFAllocatorRef;
 
 // CoreFoundation/CFString.h
 typedef UInt32 CFStringEncoding;
 CFIndex CFStringGetLength(CFStringRef theString);
 Boolean CFStringGetCString(CFStringRef theString, char *buffer, CFIndex bufferSize, CFStringEncoding encoding);
+extern CFStringRef CFStringCreateWithCString(CFAllocatorRef alloc, const char *cStr, CFStringEncoding encoding);
+
+// CoreFoundation/CFDictionary.h
+typedef const void *            CFDictionaryRef;
+typedef const void *            CFMutableDictionaryRef;
+typedef const void *	        (*CFDictionaryRetainCallBack)(CFAllocatorRef allocator, const void *value);
+typedef void		            (*CFDictionaryReleaseCallBack)(CFAllocatorRef allocator, const void *value);
+typedef CFStringRef	            (*CFDictionaryCopyDescriptionCallBack)(const void *value);
+typedef Boolean		            (*CFDictionaryEqualCallBack)(const void *value1, const void *value2);
+typedef CFHashCode	            (*CFDictionaryHashCallBack)(const void *value);
+
+typedef struct {
+    CFIndex				version;
+    CFDictionaryRetainCallBack		retain;
+    CFDictionaryReleaseCallBack		release;
+    CFDictionaryCopyDescriptionCallBack	copyDescription;
+    CFDictionaryEqualCallBack		equal;
+    CFDictionaryHashCallBack		hash;
+} CFDictionaryKeyCallBacks;
+
+typedef struct {
+    CFIndex				version;
+    CFDictionaryRetainCallBack		retain;
+    CFDictionaryReleaseCallBack		release;
+    CFDictionaryCopyDescriptionCallBack	copyDescription;
+    CFDictionaryEqualCallBack		equal;
+} CFDictionaryValueCallBacks;
+
+extern CFMutableDictionaryRef CFDictionaryCreateMutable(
+        CFAllocatorRef allocator,
+        CFIndex capacity,
+        const CFDictionaryKeyCallBacks *keyCallBacks,
+        const CFDictionaryValueCallBacks *valueCallBacks);
+extern void CFDictionaryAddValue(
+        CFMutableDictionaryRef theDict,
+        const void *key,
+        const void *value);
+
+
+// objc/objc.h
+typedef struct objc_object *id;
+typedef struct objc_selector *SEL;
+extern SEL sel_registerName(const char *str);
+
+// objc/message.h
+extern id objc_msgSend(id self, SEL op, ...);
+
+// objc/runtime.h
+extern id objc_getClass(const char *name);
+
 
 // CoreFoundation/CFRunLoop.h
 typedef struct __CFRunLoop * CFRunLoopRef;
@@ -73,6 +125,16 @@ OSStatus AudioObjectSetPropertyData(AudioObjectID inObjectID,
                                     const void* inQualifierData,
                                     UInt32 inDataSize,
                                     const void* inData);
+
+extern OSStatus AudioHardwareCreateAggregateDevice(CFDictionaryRef inDescription,
+                                                   AudioObjectID  *outDeviceID);
+extern OSStatus AudioHardwareDestroyAggregateDevice(AudioObjectID inDeviceID);
+
+
+// CoreAudio/AudioHardwareTapping.h
+extern OSStatus AudioHardwareCreateProcessTap(id inDescription,
+                                              AudioObjectID *outTapID);
+extern OSStatus AudioHardwareDestroyProcessTap(AudioObjectID inTapID);
 
 
 // CoreAudioTypes.h


### PR DESCRIPTION
This is my first attempt at integrating loopback recording on Mac as mentioned in #194.

For now, I placed the code necessary to generate the loopback device under the helper class `_CoreAudio`. Let me know if you would prefer it having its own helper class.

Based on the requirements for this [sample project](https://developer.apple.com/documentation/coreaudio/capturing-system-audio-with-core-audio-taps?language=objc) from Apple, I decided to check for loopback support using `platform.mac_ver` and setting 14.2 as a minimum requirement.

With the current implementation, once the user calls `all_microphones(include_loopback=True)` for the first time, a `loopback device` is created. Its `id` is used as a key in the dictionary `_CoreAudio.loopback_devices` while the `id` of the `tap object` is stored as its value. Whether or not a device is loopback is determined by its id being present in the dictionary.

This id values can be used to destroy the device. I am uncertain whether or not there is a need to actively destroy every device. I set them up to be private which means they are linked to, and only accessible from, the process which created them and from my observations they seem to disappear once the process is stopped.

If I can manage to make process inclusion and exclusion work under cffi, I was thinking the `create_loopback_device` function could be exposed to the user to give better control over the `tap options`. If you think it would be outside the scope of this library let me know.