### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,8 @@ please open an Issue, and I will try to fix it. Or open a Pull Request, and I
 will try to include your fix into SoundCard.
 
 However, please be aware that this is a hobby project of mine that I am
-developing for free, and in my spare time. While I try to be as accomodating as
-possible, I can not guarantee a timely response to issues. Publishing Open
+developing for free, and in my spare time. While I try to be as accommodating
+as possible, I can not guarantee a timely response to issues. Publishing Open
 Source Software on Github does not imply an obligation to *fix your problem
 right now*. Please be civil.
 

--- a/soundcard/coreaudio.py
+++ b/soundcard/coreaudio.py
@@ -393,7 +393,7 @@ class _AudioUnit:
     """Communication helper with AudioUnits.
 
     This provides an abstraction over a single AudioUnit. Can be used
-    as soon as it instatiated.
+    as soon as it instantiated.
 
     Properties:
     - `enableinput`, `enableoutput`: set up the AudioUnit for playback

--- a/soundcard/pulseaudio.py
+++ b/soundcard/pulseaudio.py
@@ -72,7 +72,7 @@ def channel_name_map():
 
 
 class _PulseAudio:
-    """Proxy for communcation with Pulseaudio.
+    """Proxy for communication with Pulseaudio.
 
     This holds the pulseaudio main loop, and a pulseaudio context.
     Together, these provide the building blocks for interacting with
@@ -102,7 +102,7 @@ class _PulseAudio:
 
     @staticmethod
     def _infer_program_name():
-        """Get current progam name.
+        """Get current program name.
 
         Will handle `./script.py`, `python path/to/script.py`,
         `python -m module.submodule` and `python -c 'code(x=y)'`.


### PR DESCRIPTION
Fix typos discovered by codespell - https://pypi.org/project/codespell

% `codespell --ignore-words-list=datas,fo,unknwn`
```
./README.rst:27: accomodating ==> accommodating
./soundcard/coreaudio.py:396: instatiated ==> instantiated
./soundcard/pulseaudio.py:75: communcation ==> communication
./soundcard/pulseaudio.py:105: progam ==> program
```
% `codespell --ignore-words-list=datas,fo,unknwn --write-changes` 